### PR TITLE
bypass some warnings

### DIFF
--- a/sortgs.py
+++ b/sortgs.py
@@ -233,6 +233,11 @@ def main():
         mydivs = soup.findAll("div", { "class" : "gs_or" })
 
         for div in mydivs:
+            if div.find("h2") and div.find("h2").text == "Related searches":
+                continue
+            if div.find("span", { "class" : "gs_lbl" }) and div.find("span", { "class" : "gs_lbl" }).text == "Create alert":
+                continue
+
             try:
                 links.append(div.find('h3').find('a').get('href'))
             except: # catch *all* exceptions


### PR DESCRIPTION
bypass some warnings caused by "Related searches" and "Create alert" `div`s:

```html
<div class="gs_r gs_alrt_btm gs_oph gs_ota">
    <a class="gs_btnM gs_in_ib" href="/scholar_alerts?view_op=create_alert_options&amp;hl=en&amp;alert_query=allintitle:+ ... ">
        <span class="gs_ico"></span>
        <span class="gs_lbl">Create alert</span>
    </a>
</div>
```

```html


<div class="gs_qsuggest_wrap gs_r">
    <div class="gs_qsuggest gs_qsuggest_regular">
        <h2>Related searches</h2>
        <ul>
            <li><a href="/scholar?hl=en&amp;oe=ASCII&amp;as_sdt=0,5&amp;qsp=1&amp;q=...">...</a></li>
             <!-- ... -->
        </ul>
    </div>
</div>
```
